### PR TITLE
Updated readme.md marking a deprecated ref

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,7 @@ Hear how Soundcloud ["Move Fast and Consumer-Driven-Contract-Testing Things"](ht
 - [Ruby Pact](https://github.com/realestate-com-au/pact)
 - [JVM Pact](https://github.com/DiUS/pact-jvm) and [Scala-Pact](https://github.com/ITV/scala-pact)
 - [.NET Pact](https://github.com/SEEK-Jobs/pact-net)
-- [JS Pact](https://github.com/DiUS/pact-consumer-js-dsl)
+- ~~[JS Pact](https://github.com/DiUS/pact-consumer-js-dsl)~~ *superceded by* [Pact JS](https://github.com/pact-foundation/pact-js)
 - [Go Pact](https://github.com/pact-foundation/pact-go) (there is also a v1.1 native [Pact Go](https://github.com/SEEK-Jobs/pact-go))
 - [Swift / Objective-C Pact](https://github.com/DiUS/pact-consumer-swift)
 


### PR DESCRIPTION
Marked ref to 'JS Pack' as deprecated and added reference to 'Pack JS'.