### PR TITLE
Fix repo links

### DIFF
--- a/faq/README.md
+++ b/faq/README.md
@@ -124,7 +124,7 @@ If you work in a more traditional "Big Bang Release" environment, choose end to 
 
 Consumer driven contracts to some extent allows you to do away with versioning. As long as all your contract tests pass, you should be able to deploy changes without versioning the API. If you need to make a breaking change to a provider, you can do it in a multiple step process - add the new fields/endpoints to the provider and deploy. Update the consumers to use the new fields/endpoints, then deploy. Remove the old fields/endpoints from the provider and deploy. At each step of the process, all the contract tests remain green.
 
-Using a [Pact Broker](https://github.com/bethesque/pact_broker), you can tag the production version of a pact when you make a release of a consumer. Then, any changes that you make to the provider can be checked agains the production version of the pact, as well as the latest version, to ensure backward compatiblity.
+Using a [Pact Broker](https://github.com/pact-foundation/pact_broker), you can tag the production version of a pact when you make a release of a consumer. Then, any changes that you make to the provider can be checked agains the production version of the pact, as well as the latest version, to ensure backward compatiblity.
 
 If you need to support multiple versions of the provider API concurrently, then you will probably be specifying which version your consumer uses by setting a header, or using a different URL component. As these are actually different requests, the interactions can be verified in the same pact without any problems.
 

--- a/faq/convinceme.md
+++ b/faq/convinceme.md
@@ -28,7 +28,7 @@ Pact is like VCR in reverse. VCR records actual provider behaviour, and verifies
 - Well documented use cases ("Given ... a request for ... will return ...") that show exactly how a provider is being used.
 - The ability to see exactly which fields each consumer is interested in, allowing unused fields to be removed, and new fields to be added in the provider API without impacting a consumer.
 - The ability to immediately see which consumers will be broken if a change is made to the provider API.
-- When using the [Pact Broker](https://github.com/bethesque/pact_broker), the ability to map the relationships between your services.
+- When using the [Pact Broker](https://github.com/pact-foundation/pact_broker), the ability to map the relationships between your services.
 
 See [https://github.com/pact-foundation/pact-ruby/wiki/FAQ#how-does-pact-differ-from-vcr](https://github.com/pact-foundation/pact-ruby/wiki/FAQ#how-does-pact-differ-from-vcr) for more examples of similar technologies.
 

--- a/getting_started/README.md
+++ b/getting_started/README.md
@@ -178,7 +178,7 @@ Pact.service_provider "Animal Service" do
   honours_pact_with 'Zoo App' do
 
     # This example points to a local file, however, on a real project with a continuous
-    # integration box, you would use a [Pact Broker](https://github.com/bethesque/pact_broker) or publish your pacts as artifacts,
+    # integration box, you would use a [Pact Broker](https://github.com/pact-foundation/pact_broker) or publish your pacts as artifacts,
     # and point the pact_uri to the pact published by the last successful build.
 
     pact_uri '../zoo-app/specs/pacts/zoo_app-animal_service.json'

--- a/getting_started/sharing_pacts.md
+++ b/getting_started/sharing_pacts.md
@@ -100,7 +100,7 @@ See the [full API](https://github.com/pact-foundation/pact_broker/wiki/Publishin
 * See the [API definition](https://github.com/pact-foundation/pact_broker/wiki/Publishing-and-retrieving-pacts) with `cURL` examples
 
 
-For more information head over to the Pact Broker [website](https://github.com/bethesque/pact_broker).
+For more information head over to the Pact Broker [website](https://github.com/pact-foundation/pact_broker).
 
 ## Alternative approaches
 

--- a/implementation_guides/other_languages.md
+++ b/implementation_guides/other_languages.md
@@ -18,7 +18,7 @@ This setup simplifies Pact Provider verification process in any language.
 The two solutions below use the [Docker](https://github.com/DiUS/pact-provider-verifier-docker) image
 and the [Pact Provider Verifier](https://github.com/pact-foundation/pact-provider-verifier)
 Gem. For advanced usage, you can use
-[Pact Provider Proxy](https://github.com/bethesque/pact-provider-proxy) Gem
+[Pact Provider Proxy](https://github.com/pact-foundation/pact-provider-proxy) Gem
 directly, however in most cases the Pact Provider Verifier should cover your needs.
 
 ### How it works

--- a/implementation_guides/ruby/README.md
+++ b/implementation_guides/ruby/README.md
@@ -175,7 +175,7 @@ Pact.service_provider "Animal Service" do
   honours_pact_with 'Zoo App' do
 
     # This example points to a local file, however, on a real project with a continuous
-    # integration box, you would use a [Pact Broker](https://github.com/bethesque/pact_broker) or publish your pacts as artifacts,
+    # integration box, you would use a [Pact Broker](https://github.com/pact-foundation/pact_broker) or publish your pacts as artifacts,
     # and point the pact_uri to the pact published by the last successful build.
 
     pact_uri '../zoo-app/specs/pacts/zoo_app-animal_service.json'

--- a/implementation_guides/ruby/verifying_pacts.md
+++ b/implementation_guides/ruby/verifying_pacts.md
@@ -110,7 +110,7 @@ At some stage, you'll want to be able to run your specs one at a time while you 
 ## Verifying pacts for non-Rack apps
 
 ### Ruby apps
-If your app is a non-Rack Ruby app, you may be able to find a Rack adapter for it. If you can do this, then configure the `app` in the `Pact.service_provider` block to point to an instance of your adapter. Otherwise, use the [pact-provider-proxy](https://github.com/bethesque/pact-provider-proxy) gem.
+If your app is a non-Rack Ruby app, you may be able to find a Rack adapter for it. If you can do this, then configure the `app` in the `Pact.service_provider` block to point to an instance of your adapter. Otherwise, use the [pact-provider-proxy](https://github.com/pact-foundation/pact-provider-proxy) gem.
 
 ## Configuring RSpec
 


### PR DESCRIPTION
The current Pact Broker link especially is not quite right, since it's now pointing at a personal fork rather than redirecting to the canonical repo location.