### PR TITLE
Fix the format of a comment

### DIFF
--- a/implementation_guides/javascript.md
+++ b/implementation_guides/javascript.md
@@ -37,7 +37,7 @@ global.provider = new Pact({
 ```
  Global setup for Jest is handled with `pactTestWrapper.js`:
 ```javascript
-jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; //* This is to give the pact mock server time to start
+jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000; // This is to give the pact mock server time to start
 
 beforeAll(() => provider.setup()); // Create mock provider
 afterEach(() => provider.verify()); // Ensure the mock provider verifies expected interactions for each test


### PR DESCRIPTION
Since the `/*` is never closed, it causes the formatting of this code block to look off

![image](https://user-images.githubusercontent.com/828610/45308089-4f41f300-b4e6-11e8-8a53-a3fb7b3265dc.png)
