### PR TITLE
replace broken links

### DIFF
--- a/best_practices/consumer/README.md
+++ b/best_practices/consumer/README.md
@@ -53,5 +53,5 @@ If, for performance reasons, you don’t want to include the updated resource in
 
 ## Use `can-i-deploy`
 
-Use the [can-i-deploy](https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-results) feature of the [Pact Broker CLI](https://github.com/pact-foundation/pact_broker-client#can-i-deploy). It will give you a definitive answer if the version of your consumer that is being deployed, is compatible with all of its providers.
+Use the [can-i-deploy](../../pact_broker/advanced_topics/provider_verification_results.md) feature of the [Pact Broker CLI](https://github.com/pact-foundation/pact_broker-client#can-i-deploy). It will give you a definitive answer if the version of your consumer that is being deployed, is compatible with all of its providers.
 

--- a/best_practices/pact_nirvana.md
+++ b/best_practices/pact_nirvana.md
@@ -11,7 +11,7 @@ Although many guides assume a greenfields project with no existing code, this do
 Before you read this document, you should:
 
 * have a basic understanding of the concepts of both [consumer driven contracts](https://martinfowler.com/articles/consumerDrivenContracts.html) and Pact,
-* have read the [Pact Broker Overview](https://github.com/pact-foundation/pact_broker/wiki/Overview)
+* have read the [Pact Broker Overview](../pact_broker/overview.md)
 * have read the section on [Pacticipant version numbers](../getting_started/versioning_in_the_pact_broker.md)
 
 ### How to use this document
@@ -85,7 +85,7 @@ The Pact Broker and its clients are open source tools \(though you can get your 
 
 ### A. Set up a Pact Broker
 
-1. Read the Pact Broker [home page](https://github.com/pact-foundation/pact_broker), \(taking note of the various deployment options available to you\) and the [quick start guide](https://github.com/pact-foundation/pact_broker/wiki#quick-start-guide).
+1. Read the Pact Broker [home page](https://github.com/pact-foundation/pact_broker), \(taking note of the various deployment options available to you\) and the [quick start guide](../pact_broker/README.md).
 2. Deploy a Pact Broker to a network that has access to both consumer and provider CI systems so it can trigger builds.
 
 ### B. Configure pact publication
@@ -99,16 +99,16 @@ The Pact Broker and its clients are open source tools \(though you can get your 
 ### D. Configure pact to be verified when contract changes
 
 1. Create a new CI job that performs just the provider pact verification step for a given pact URL \(consult the documentation for your chosen language for how to configure this\). The job should accept the URL of the changed pact in the HTTP request parameters or body.
-2. Configure a [webhook](https://github.com/pact-foundation/pact_broker/wiki/Webhooks) to kick off the provider verification build when a pact changes, and use [webhook templates](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/doc/views/webhooks.markdown#dynamic-variable-substitution) to pass the URL of the changed pact to the build.
+2. Configure a [webhook](../pact_broker/advanced_topics/webhooks/webhooks.md) to kick off the provider verification build when a pact changes, and use [webhook templates](https://github.com/pact-foundation/pact_broker/blob/master/lib/pact_broker/doc/views/webhooks.markdown#dynamic-variable-substitution) to pass the URL of the changed pact to the build.
 
 As you have two different builds running the pact verifications (one when the provider changes, one when the contract changes) it is best to use a provider version number that is deterministic (eg. does not include your CI build number) so that a verification from either job is recorded with the same version number. This will help you when it comes to using the `can-i-deploy` tool in step 7. Please read the section on [versioning in the Pact Broker](https://docs.pact.io/getting_started/versioning_in_the_pact_broker) to ensure your version numbers will help you get the most out of your Pact Broker.
 
 Useful links:
 
 * [Installing a Docker Pact Broker](https://hub.docker.com/r/pactfoundation/pact-broker)
-* [Publishing verification results](https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-results)
-* [Configuring webhooks in the Pact Broker](https://github.com/pact-foundation/pact_broker/wiki/Webhooks)
-* [Adding verification badges to your READMEs](https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-badges)
+* [Publishing verification results](../pact_broker/advanced_topics/provider_verification_results.md)
+* [Configuring webhooks in the Pact Broker](../pact_broker/advanced_topics/webhooks/webhooks.md)
+* [Adding verification badges to your READMEs](../pact_broker/advanced_topics/provider_verification_badges.md)
 * [Versioning in the Pact Broker](https://docs.pact.io/getting_started/versioning_in_the_pact_broker)
 
 ## 5. Allow contracts to change without breaking your builds

--- a/best_practices/provider/README.md
+++ b/best_practices/provider/README.md
@@ -27,11 +27,11 @@ See [this gist](https://gist.github.com/bethesque/43eef1bf47afea4445c8b8bdebf28d
 
 ### Publish verification results to the Pact Broker
 
-As of version 2.0+ of the Pact Broker, and 1.11.1+ of the Pact Ruby implementation, provider verification results can be [published](https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-results) back to the broker, and will be displayed on the index page. The consumer team should consult the verification status on the index page before deploying.
+As of version 2.0+ of the Pact Broker, and 1.11.1+ of the Pact Ruby implementation, provider verification results can be [published](../../pact_broker/advanced_topics/provider_verification_results.md) back to the broker, and will be displayed on the index page. The consumer team should consult the verification status on the index page before deploying.
 
 One catch - it is only safe to deploy the consumer if it was verified against the _production_ version of the provider.
 
 ## Use `can-i-deploy`
 
-Use the [can-i-deploy](https://github.com/pact-foundation/pact_broker/wiki/Provider-verification-results) feature of the [Pact Broker CLI](https://github.com/pact-foundation/pact_broker-client#can-i-deploy). It will give you a definitive answer if the version of your provider that is being deployed, is compatible with all of its known consumers.
+Use the [can-i-deploy](../../pact_broker/advanced_topics/provider_verification_results.md) feature of the [Pact Broker CLI](https://github.com/pact-foundation/pact_broker-client#can-i-deploy). It will give you a definitive answer if the version of your provider that is being deployed, is compatible with all of its known consumers.
 

--- a/pact_broker/README.md
+++ b/pact_broker/README.md
@@ -139,7 +139,7 @@ You can use the [Pact Broker Docker image][docker] or [Terraform on AWS][terrafo
 
 [decouple]: http://techblog.realestate.com.au/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/
 [pact]: https://github.com/pact-foundation/pact-ruby
-[nerf]: https://github.com/pact-foundation/pact_broker/wiki/pact-broker-ci-nerf-gun
+[nerf]: nerf.md
 [different-teams]: https://github.com/pact-foundation/pact-ruby/wiki/Using-pact-where-the-consumer-team-is-different-from-the-provider-team
 [docker]: https://hub.docker.com/r/pactfoundation/pact-broker
 [terraform]: https://github.com/nadnerb/terraform-pact-broker

--- a/pact_broker/README.md
+++ b/pact_broker/README.md
@@ -144,7 +144,6 @@ You can use the [Pact Broker Docker image][docker] or [Terraform on AWS][terrafo
 [docker]: https://hub.docker.com/r/pactfoundation/pact-broker
 [terraform]: https://github.com/nadnerb/terraform-pact-broker
 [hosted]: https://pact.dius.com.au/?utm_source=github&utm_campaign=GITHUB_BROKER&utm_medium=github
-[wiki]: https://github.com/pact-foundation/pact_broker/wiki
 [stackoverflow]: http://stackoverflow.com/questions/tagged/pact-broker
 [twitter]: https://twitter.com/pact_up
 [slack]: https://slack.pact.io/

--- a/pact_broker/nerf.md
+++ b/pact_broker/nerf.md
@@ -1,0 +1,3 @@
+# Pact Broker CI Nerf Gun
+
+I wish.

--- a/pact_broker/overview.md
+++ b/pact_broker/overview.md
@@ -18,7 +18,7 @@ A pact is published using the consumer name, the provider name, and the consumer
 
 ## Pacticipant versions
 
-A pacticipant has many pacticipant versions (ie. application versions). A version is identified by its [version number](pacticipant_version_numbers.md) which would typically be a git sha (or subversion revision number), or a semantic version number with a repository reference as metadata. A pacticipant version resource will be automatically created every time a pact or a verification result is published (if it did not already exist). A pacticipant version will have a pact associated with it if it is a consumer version, and it will have a verification result it if is a provider version.
+A pacticipant has many pacticipant versions (ie. application versions). A version is identified by its [version number][pacticipant-version-numbers] which would typically be a git sha (or subversion revision number), or a semantic version number with a repository reference as metadata. A pacticipant version resource will be automatically created every time a pact or a verification result is published (if it did not already exist). A pacticipant version will have a pact associated with it if it is a consumer version, and it will have a verification result it if is a provider version.
 
 ## Verifications
 
@@ -65,4 +65,5 @@ The HAL specification also provides a built in method for providing documentatio
 * Note that if you publish a pact, the consumer, provider and consumer version resources are automatically created, however, if you delete a pact, they are not automatically deleted, so you may have orphan data lying around that will give you inconsistent results when you query the broker.
 
 [can-i-deploy]: https://github.com/pact-foundation/pact_broker-client#can-i-deploy
+[pacticipant-version-numbers]: pacticipant_version_numbers.md
 


### PR DESCRIPTION
This PR replaces some broken links to https://github.com/pact-foundation/pact_broker/wiki/

I was not able to update the html files in ./_book
What is the correct command and gitbook version?

references: 
pact-foundation/pact_broker#281
