### PR TITLE
fix contract testing best practices link

### DIFF
--- a/getting_started/how_pact_works.md
+++ b/getting_started/how_pact_works.md
@@ -88,7 +88,7 @@ If we pair the test and verification process for each interaction, the contract 
 
 ## Next steps
 
-_Contract tests should focus on the messages \(requests and responses\) rather than the behaviour_. It can be tempting to use contract tests to write general functional tests for the provider. Experience shows this to leads to painful experiences with brittle tests. See [this guide for contract testing best practices](https://github.com/pact-foundation/pact.io/tree/06c43f405a523d09d103a420c9580c7b8b670df6/best-practices/consumer/contract-tests-vs-functional-tests/README.md).
+_Contract tests should focus on the messages \(requests and responses\) rather than the behaviour_. It can be tempting to use contract tests to write general functional tests for the provider. Experience shows this to leads to painful experiences with brittle tests. See [this guide for contract testing best practices](https://github.com/pact-foundation/pact.io/blob/06c43f405a523d09d103a420c9580c7b8b670df6/best_practices/consumer/contract_tests_not_functional_tests.md).
 
 _Pact tests should be data independent_. Pact tests are best when successful verification doesn’t depend on the specific data that the provider returns. See this guide for best practices when describing interactions.
 


### PR DESCRIPTION
https://github.com/pact-foundation/pact.io/tree/06c43f405a523d09d103a420c9580c7b8b670df6/best-practices/consumer/contract-tests-vs-functional-tests/README.md

changed to

https://github.com/pact-foundation/pact.io/blob/06c43f405a523d09d103a420c9580c7b8b670df6/best_practices/consumer/contract_tests_not_functional_tests.md