### PR TITLE
test: redirects for installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,46 @@ Python 2 is required due to an old version of node-sass.
 The short version:
 
 * npm install
-* $(npm bin)/gulp
+* npx netlify-cli dev
 
+## Redirects
 
-#### MacOS
+### Unix (sh)
 
+```sh
+curl -fsSL pact.io/sh | sh -
 ```
-brew install pyenv
-eval "$(pyenv init -)" # set in your profile (.zshrc / .bashrc etc)
-pyenv install 2.7.18
-pyenv shell 2.7.18
-... npm commands above
+
+### Windows (ps1)
+
+```ps1
+iwr -useb pact.io/ps1 | iex
+```
+
+### Windows (choco)
+
+```ps1
+curl pact.io/choco/<version> -OutFile <pkg_name>.nupkg
+choco install -y <pkg_name> --source .
+```
+
+#### Choco x64
+
+```ps1
+curl pact.io/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
+choco install -y pact --source .
+```
+
+#### Choco arm64
+
+```ps1
+curl pact.io/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
+choco install -y pact --params "'/ForceARM64:true'"  --source .
+```
+
+### Windows (scoop)
+
+```ps1
+scoop bucket add pact pact.io/scoop
+scoop install pact
 ```

--- a/config/_redirects
+++ b/config/_redirects
@@ -10,3 +10,7 @@
 /pactober/workshop/watch        https://www.youtube.com/watch?v=0FpzPRSf2VA
 /pactober/feedback              https://cucumber.typeform.com/to/xO0II3dk
 /pactober/workshop/watch/pact-jvm-dsl  https://www.youtube.com/watch?v=whXaNti7PSg
+/sh     https://raw.githubusercontent.com/pact-foundation/pact-cli/main/install.sh
+/ps1    https://raw.githubusercontent.com/pact-foundation/pact-cli/main/install.ps1
+/scoop/*  https://github.com/pact-foundation/scoop/:splat
+/choco/*  https://github.com/pact-foundation/choco/releases/download/choco/:splat

--- a/netlify.toml
+++ b/netlify.toml
@@ -18,3 +18,19 @@
   from = "/pactober/2023/pact-jvm-dsl.html"
   to = "/pactober/2023/pact-jvm-dsl"
   status = 200
+[[redirects]]
+  from = "/sh"
+  to = "https://raw.githubusercontent.com/pact-foundation/pact-cli/main/install.sh"
+  status = 200
+[[redirects]]
+  from = "/ps1"
+  to = "https://raw.githubusercontent.com/pact-foundation/pact-cli/main/install.ps1"
+  status = 200
+[[redirects]]
+  from = "/scoop/*"
+  to = "https://github.com/pact-foundation/scoop/:splat"
+  status = 200
+[[redirects]]
+  from = "/choco/*"
+  to = " https://github.com/pact-foundation/choco/releases/download/choco/:splat"
+  status = 200


### PR DESCRIPTION
For Testing

## Redirects

#### MacOS	

### Unix (sh)

```sh
curl -fsSL https://deploy-preview-268--pact-io.netlify.app/sh | sh -
```
### Windows

```ps1
iwr -useb https://deploy-preview-268--pact-io.netlify.app/ps1 | iex
```

### Windows (choco)

```ps1
curl https://deploy-preview-268--pact-io.netlify.app/choco/<version> -OutFile <pkg_name>.nupkg
choco install -y <pkg_name> --source .
```

#### Choco x64

```ps1
curl https://deploy-preview-268--pact-io.netlify.app/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
choco install -y pact --source .
```

#### Choco arm64

```ps1
curl https://deploy-preview-268--pact-io.netlify.app/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
choco install -y pact --params "'/ForceARM64:true'"  --source .
```

### Windows (scoop)

```ps1
scoop bucket add pact https://deploy-preview-268--pact-io.netlify.app/scoop
scoop install pact
```


Potential links in production


## Redirects

#### MacOS	

### Unix (sh)

```sh
curl -fsSL pact.io/sh | sh -
```
### Windows

```ps1
iwr -useb pact.io/ps1 | iex
```

### Windows (choco)

```ps1
curl pact.io/choco/<version> -OutFile <pkg_name>.nupkg
choco install -y <pkg_name> --source .
```

#### Choco x64

```ps1
curl pact.io/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
choco install -y pact --source .
```

#### Choco arm64

```ps1
curl pact.io/choco/pact.0.9.1.nupkg -OutFile pact.nupkg
choco install -y pact --params "'/ForceARM64:true'"  --source .
```

### Windows (scoop)

```ps1
scoop bucket add pact pact.io/scoop
scoop install pact
```
